### PR TITLE
Exit with 1 when copr build fails

### DIFF
--- a/copr/.flake8
+++ b/copr/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/copr/create_build.py
+++ b/copr/create_build.py
@@ -3,22 +3,22 @@
 import subprocess
 import time
 import os
+import sys
 from copr.v3 import Client, CoprNoResultException
 
-key = os.environ['KEY']
-iv = os.environ['IV']
+key = os.environ["KEY"]
+iv = os.environ["IV"]
 
-owner = os.environ['OWNER']
-project = os.environ['PROJECT']
-package = os.environ['PACKAGE']
-clone_url = os.environ['CLONE_URL']
-ish = os.environ.get('COMMITISH', 'master')
-spec = os.environ['SPEC']
+owner = os.environ["OWNER"]
+project = os.environ["PROJECT"]
+package = os.environ["PACKAGE"]
+clone_url = os.environ["CLONE_URL"]
+ish = os.environ.get("COMMITISH", "master")
+spec = os.environ["SPEC"]
 
-res = subprocess.run([
-    "openssl", "aes-256-cbc", "-K", key, "-iv", iv, "-in",
-    "/tmp/copr-mfl.enc", "-out", "/root/.config/copr", "-d"
-])
+res = subprocess.run(
+    ["openssl", "aes-256-cbc", "-K", key, "-iv", iv, "-in", "/tmp/copr-mfl.enc", "-out", "/root/.config/copr", "-d"]
+)
 
 if res.stderr:
     print("stdout: {}, stderr: {}".format(res.stdout, res.stderr))
@@ -31,20 +31,19 @@ try:
     client.package_proxy.get(*args)
 except CoprNoResultException:
     client.package_proxy.add(
-        *args,
-        source_type='scm',
-        source={
-            clone_url: clone_url,
-            source_build_method: 'make_srpm',
-            spec: spec
-        })
+        *args, source_type="scm", source={"clone_url": clone_url, "source_build_method": "make_srpm", "spec": spec}
+    )
 
 build = client.package_proxy.build(*args)
 
-while client.build_proxy.get(build.id).state in ['running', 'pending', 'starting', 'importing']:
+while client.build_proxy.get(build.id).state in ["running", "pending", "starting", "importing"]:
     time.sleep(10)
-    print("{} running".format(build.id))
+    print("{} running. State: {}".format(build.id), client.build_proxy.get(build.id).state)
 
-print("build {} finshed. State: {}".format(
-    build.id,
-    client.build_proxy.get(build.id).state))
+final_state = client.build_proxy.get(build.id).state
+
+print("build {} finshed. State: {}".format(build.id, final_state))
+
+
+if final_state == "failed":
+    sys.exit(1)

--- a/copr/pyproject.toml
+++ b/copr/pyproject.toml
@@ -1,0 +1,13 @@
+[tool.black]
+line-length = 120
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | \.tox
+  | \.venv
+  | _build
+  | build
+  | dist
+)/
+'''


### PR DESCRIPTION
We are currently exiting with 0 when the copr build fails,
which makes it look like a deploy worked when it did not.

Exit with 1 if the state is failed.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>