### PR TITLE
Add SRPM file upload support

### DIFF
--- a/copr/Dockerfile
+++ b/copr/Dockerfile
@@ -1,9 +1,13 @@
-FROM fedora:latest
+FROM centos:latest
 WORKDIR /build
-RUN dnf install -y 'dnf-command(copr)' \
+RUN yum install -y dnf epel-release \
+  && yum install -y yum-plugin-copr \
+  && dnf install -y 'dnf-command(copr)' \
   && dnf install -y python openssl \
   && dnf copr enable -y @copr/copr \
   && dnf install -y copr-cli \
+  && yum clean all \
+  && dnf clean all \
   && mkdir /root/.config \
   && touch /root/.config/copr
 ADD copr-mfl.enc /tmp


### PR DESCRIPTION
This patch adds support to upload a built SRPM directly to Copr.

The default make srpm is still supported as well.

To use upload support:

```bash
export OWNER=managerforlustre
export PROJECT=manager-for-lustre-devel
export SRPM_PATH='/tmp/*.src.rpm'

docker run -dit --entrypoint "/bin/bash" --name "copr" -e OWNER="$OWNER" -e PROJECT="$PROJECT" -e KEY="$encrypted_253525cedcf6_key" -e IV="$encrypted_253525cedcf6_iv" -v $(pwd):/build:rw imlteam/copr
docker exec -it mock bash -xec '<STEPS TO PRODUCE SRPM HERE>'
docker exec -it mock bash -xec 'create_build'
```

The entrypoint is overridden to allow for manual building.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>