### PR TITLE
Update copr container to run make on the Makefile if the srpm_path is…

### DIFF
--- a/copr/Dockerfile
+++ b/copr/Dockerfile
@@ -2,8 +2,6 @@ FROM centos:latest
 WORKDIR /build
 RUN yum install -y dnf epel-release \
   && yum install -y yum-plugin-copr \
-  && yum install -y openssl \
-  && yum install -y openssl-devel \
   && dnf install -y 'dnf-command(copr)' \
   && dnf install -y python openssl \
   && dnf copr enable -y @copr/copr \

--- a/copr/Dockerfile
+++ b/copr/Dockerfile
@@ -2,10 +2,14 @@ FROM centos:latest
 WORKDIR /build
 RUN yum install -y dnf epel-release \
   && yum install -y yum-plugin-copr \
+  && yum install -y openssl \
+  && yum install -y openssl-devel \
   && dnf install -y 'dnf-command(copr)' \
   && dnf install -y python openssl \
   && dnf copr enable -y @copr/copr \
   && dnf install -y copr-cli \
+  && yum -y copr enable -y managerforlustre/buildtools \
+  && yum install -y rust-bundled-packaging spectool \
   && yum clean all \
   && dnf clean all \
   && mkdir /root/.config \


### PR DESCRIPTION
… specified

Description:
Currently, when attempting to package a project inside of a subdirectory of a repo the builder will attempt to run make
inside the root folder instead of the subdirectory. This patch specifies the `project_dirname` (if specified) when
building. Additionally, if the user specifies an srpm path it will first check to see if the srpm exists in the
specified path. If it doesn't exist, it will run make and assign the outdir to the environemnt variable. Once make
completes, it will upload the srpm to the copr repository where it will be built.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>