### PR TITLE
Add subdirectory property to source dict if it exists

### DIFF
--- a/copr/create_build.py
+++ b/copr/create_build.py
@@ -47,11 +47,11 @@ else:
     try:
         client.package_proxy.get(*args)
     except CoprNoResultException:
-        client.package_proxy.add(
-            *args,
-            source_type="scm",
-            source_dict={"clone_url": clone_url, "source_build_method": "make_srpm", "spec": spec, "committish": ish}
-        )
+        source_dict = {"clone_url": clone_url, "source_build_method": "make_srpm", "spec": spec, "committish": ish}
+        if project_dirname is not None:
+            source_dict["subdirectory"] = project_dirname
+
+        client.package_proxy.add(*args, source_type="scm", source_dict=source_dict)
 
     build = client.package_proxy.build(*args, buildopts=None, project_dirname=project_dirname)
 


### PR DESCRIPTION
Copr doesn't seem to run make in the project_dirname. This patch adds the `subdirectory` property to the source dict if
the project_dirname is defined.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>