### PR TITLE
Auto increment release value when performing dev builds on copr

### DIFF
--- a/copr/Dockerfile
+++ b/copr/Dockerfile
@@ -4,6 +4,8 @@ RUN yum install -y dnf epel-release \
   && yum install -y yum-plugin-copr \
   && dnf install -y 'dnf-command(copr)' \
   && dnf install -y python openssl \
+  && dnf install -y python-pip \
+  && pip install packaging \
   && dnf copr enable -y @copr/copr \
   && dnf install -y copr-cli \
   && yum -y copr enable -y managerforlustre/buildtools \

--- a/copr/create_build.py
+++ b/copr/create_build.py
@@ -5,7 +5,65 @@ import time
 import os
 import sys
 import glob
+import re
 from copr.v3 import Client, CoprNoResultException
+from packaging import version
+
+version_regex = r"(\d+\.\d+\.\d)+-\d+\.(\d+)\..+"
+
+
+def get_version_from_spec(spec_file):
+    file = open(spec_file, "r")
+    spec = file.read()
+    file.close()
+
+    return re.match(r".*Version:.*(\d+\.\d+\.\d+).*", spec, re.DOTALL).group(1)
+
+
+def update_spec_with_new_release(spec_file, release_num):
+    file = open(spec_file, "r")
+    spec = file.read()
+    file.close()
+
+    return re.sub(
+        r".*# Release Start\nRelease:.*(\d)%{\?dist}\n# Release End.*",
+        "# Release Start\nRelease:    {}{}\n# Release End".format(release_num, "%{?dist}"),
+        spec,
+        re.DOTALL,
+    )
+
+
+def get_release_num(builds, version_regex, spec_file):
+    release_num = 1
+
+    try:
+        build = sorted(builds, key=lambda x: x.ended_on, reverse=True)[0]
+        v = build.source_package.get("version")
+        matches = re.match(version_regex, v)
+        ver = matches.group(1)
+
+        spec_ver = get_version_from_spec(spec_file)
+
+        if version.parse(ver) == version.parse(spec_ver):
+            release_num = int(matches.group(2)) + 1
+    except:
+        print("Initial build.")
+
+    return release_num
+
+
+def get_spec_file():
+    try:
+        return glob.glob("*.spec").pop()
+    except:
+        raise "Spec file could not be found!"
+
+
+def write_new_spec(spec_file, new_data):
+    file = open(spec_file, "w")
+    file.write(new_data)
+    file.close()
+
 
 key = os.environ["KEY"]
 iv = os.environ["IV"]
@@ -16,8 +74,9 @@ package = os.environ.get("PACKAGE")
 clone_url = os.environ.get("CLONE_URL")
 spec = os.environ.get("SPEC")
 ish = os.environ.get("COMMITISH", "master")
-srpm_path = os.environ.get("SRPM_PATH")
+srpm_path = os.environ.get("SRPM_PATH", "/tmp/*.src.rpm")
 project_dirname = os.environ.get("PROJECT_DIRNAME")
+prod = os.environ.get("PROD", False)
 
 subprocess.call(
     ["openssl", "aes-256-cbc", "-K", key, "-iv", iv, "-in", "/tmp/copr-mfl.enc", "-out", "/root/.config/copr", "-d"]
@@ -27,33 +86,34 @@ client = Client.create_from_config_file()
 
 args = (owner, project, package)
 
-if srpm_path:
-    try:
-        p = glob.glob(srpm_path).pop()
-    except:
-        subprocess.call(
-            [
-                "make",
-                "-f",
-                "/build/.copr/Makefile",
-                "srpm",
-                "outdir={}".format(srpm_path.replace(os.path.basename(srpm_path), "")),
-            ]
-        )
-        p = glob.glob(srpm_path).pop()
 
-    build = client.build_proxy.create_from_file(owner, project, p)
-else:
-    try:
-        client.package_proxy.get(*args)
-    except CoprNoResultException:
-        source_dict = {"clone_url": clone_url, "source_build_method": "make_srpm", "spec": spec, "committish": ish}
-        if project_dirname is not None:
-            source_dict["subdirectory"] = project_dirname
+try:
+    p = glob.glob(srpm_path).pop()
+except:
+    if not prod:
+        spec_file = get_spec_file()
+        epoch = int(time.time())
+        builds = client.build_proxy.get_list(*args, status="succeeded")
+        release_num = get_release_num(builds, version_regex, spec_file)
 
-        client.package_proxy.add(*args, source_type="scm", source_dict=source_dict)
+        updated_spec = update_spec_with_new_release(spec_file, "{}.{}".format(epoch, release_num))
+        write_new_spec(spec_file, updated_spec)
 
-    build = client.package_proxy.build(*args, buildopts=None, project_dirname=project_dirname)
+    # Build the SRPM
+    subprocess.call(
+        [
+            "make",
+            "-f",
+            "/build/.copr/Makefile",
+            "srpm",
+            "outdir={}".format(srpm_path.replace(os.path.basename(srpm_path), "")),
+        ]
+    )
+
+    p = glob.glob(srpm_path).pop()
+
+build = client.build_proxy.create_from_file(owner, project, p)
+
 
 while client.build_proxy.get(build.id).state in ["running", "pending", "starting", "importing"]:
     time.sleep(10)

--- a/copr/create_build.py
+++ b/copr/create_build.py
@@ -56,7 +56,7 @@ def get_spec_file():
     try:
         return glob.glob("*.spec").pop()
     except:
-        raise "Spec file could not be found!"
+        raise Exception("Spec file could not be found!")
 
 
 def write_new_spec(spec_file, new_data):


### PR DESCRIPTION
Description:

In development, we may need to push several builds to copr and then test them on multiple nodes. If a new build is
pushed to copr with the same version and release as the previous push, copr will build the rpm but it will not install
the newest package when attempting to install via yum. To resolve this issue, the builder will do the following:

1. Does an SRPM already exist? If so, just upload it.
2. Otherwise, is this a production build?
   yes:
      a. Build the SRPM using the provided spec file
      b. Upload the SRPM to copr
   no:
      a. Fetch the list of builds for the package being worked on
      b. Sort the list of builds by the "ended_on" timestamp such that the most recent build is first
      c. Extract the version and release from the most recent build
      d. Compare the version of the most recent build with the version in the spec file
         same:
            - Increment the release value from the last build by 1.
         different:
            - Set release to 1
      e. Updat the Release filed in the spec file to be: Release: <epoch>.<new_release_value>%{?dist}
      f. Build the SRPM from the new spec
      g. Upload the SRPM to copr

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>