### PR TITLE
Set CWD when invoking Make for srpm creation.

### DIFF
--- a/copr/create_build.py
+++ b/copr/create_build.py
@@ -107,7 +107,8 @@ except:
             "/build/.copr/Makefile",
             "srpm",
             "outdir={}".format(srpm_path.replace(os.path.basename(srpm_path), "")),
-        ]
+        ],
+        cwd="/build",
     )
 
     p = glob.glob(srpm_path).pop()


### PR DESCRIPTION
Many of our makefiles use `${PWD}`. Set the CWD
while invoking make so everything works.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>