### PR TITLE
Hardcode devel builds to be 0.epoch

### DIFF
--- a/copr/create_build.py
+++ b/copr/create_build.py
@@ -8,7 +8,7 @@ import glob
 import re
 from copr.v3 import Client, CoprNoResultException
 
-release_regex = r".*# Release Start\nRelease:\s*(?:(\d+)|\d+\.(\d+))%{\?dist}\n# Release End.*"
+release_regex = r".*# Release Start\nRelease:\s*(?:\d+|\d+\.\d+).*\n# Release End.*"
 valid_truthy_args = ["TRUE", "True", "true", "t", "T", "Y", "y", "YES", "Yes", "yes"]
 
 
@@ -18,9 +18,7 @@ def update_spec_with_new_release(spec_file):
     file.close()
 
     release_matches = re.match(release_regex, spec, re.DOTALL)
-    cur_rel = [x for x in release_matches.groups() if x is not None].pop()
-    print("Current release value: {}".format(cur_rel))
-    new_rel = "{}.{}".format(int(time.time()), cur_rel)
+    new_rel = "0.{}".format(int(time.time()))
     print("New release value: {}".format(new_rel))
 
     return re.sub(


### PR DESCRIPTION
Fixes #15.

Right now our devel builds do epoch.release, where epoch is num seconds since midnight 1970.

Instead, do 0.epoch so versions not built with imlteam/copr will be superior if intended.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>