### PR TITLE
Add lustre-client docker builder.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,12 @@ jobs:
         - cd mock
         - docker build -t mock .
         - docker history mock
+    - stage: build
+      name: "Build Copr Lustre"
+      script:
+        - cd lustre-client
+        - docker build -t copr-lustre .
+        - docker history copr-lustre
     - stage: cd_zfs
       name: "ZFS Continuous Deployment"
       script:
@@ -38,6 +44,13 @@ jobs:
         - cd copr
         - docker build --rm -t imlteam/copr .
         - docker push imlteam/copr
+    - stage: cd_copr_lustre
+      name: "Copr Lustre Continuous Deployment"
+      script:
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        - cd lustre-client
+        - docker build --rm -t imlteam/copr-lustre .
+        - docker push imlteam/copr-lustre
 stages:
   - build
   - name: cd_zfs
@@ -45,4 +58,6 @@ stages:
   - name: cd_mock
     if: branch = master AND type = push AND fork = false
   - name: cd_copr
+    if: branch = master AND type = push AND fork = false
+  - name: cd_copr_lustre
     if: branch = master AND type = push AND fork = false

--- a/lustre-client/Dockerfile
+++ b/lustre-client/Dockerfile
@@ -1,0 +1,4 @@
+FROM imlteam/copr
+ADD lustre-client.repo /etc/yum.repos.d
+RUN yum -y install lustre-client \
+  && yum clean all

--- a/lustre-client/lustre-client.repo
+++ b/lustre-client/lustre-client.repo
@@ -1,0 +1,6 @@
+[lustre-client]
+name=Lustre Client
+baseurl=https://downloads.whamcloud.com/public/lustre/lustre-2.10.7/el7/client/
+enabled=1
+gpgcheck=0
+repo_gpgcheck=0


### PR DESCRIPTION
Since we now install lustre-client prior to building rust-iml in copr,
add an image that extends iml-copr and installs the lustre client.

This way we won't need to install it each time we run the builder.