### PR TITLE
Create parameter to customize make srpm call

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,12 @@ jobs:
         - docker build -t mock .
         - docker history mock
     - stage: build
+      name: "Build Copr"
+      script:
+        - cd copr
+        - docker build -t copr .
+        - docker history copr
+    - stage: build
       name: "Build Copr Lustre"
       script:
         - cd lustre-client

--- a/copr/create_build.py
+++ b/copr/create_build.py
@@ -47,6 +47,7 @@ project = os.environ.get("PROJECT", "")
 package = os.environ.get("PACKAGE", "")
 spec = os.environ.get("SPEC")
 srpm_path = os.environ.get("SRPM_PATH", "/tmp/*.src.rpm")
+srpm_task = os.environ.get("SRPM_TASK", "srpm")
 prod = os.environ.get("PROD", False)
 local_only = os.environ.get("LOCAL_ONLY", False)
 
@@ -66,7 +67,7 @@ except Exception:
             "make",
             "-f",
             "/build/.copr/Makefile",
-            "srpm",
+            srpm_task,
             "outdir={}".format(srpm_path.replace(os.path.basename(srpm_path), "")),
         ],
         cwd="/build",


### PR DESCRIPTION
In monorepos where multiple modules point to the top level,
we have a naming clash between make srpm tasks.

I suspect the correct way to handle this is to put each RPM level
component in a subdir, but in the interest of time, add a way to build
srpms with different task names.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>