### PR TITLE
bump copr-lustre-client image to use 2.12.2

### DIFF
--- a/copr-lustre-client/lustre-client.repo
+++ b/copr-lustre-client/lustre-client.repo
@@ -1,6 +1,6 @@
 [lustre-client]
 name=Lustre Client
-baseurl=https://downloads.whamcloud.com/public/lustre/lustre-2.12.1/el7/client/
+baseurl=https://downloads.whamcloud.com/public/lustre/lustre-2.12.2/el7/client/
 enabled=1
 gpgcheck=0
 repo_gpgcheck=0


### PR DESCRIPTION
Signed-off-by: Joe Grund <jgrund@whamcloud.io>