### PR TITLE
Add support for building nightly rust crates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,14 @@ jobs:
         - docker build -t copr .
         - docker history copr
     - stage: build
+      name: "Build Copr Rust"
+      script:
+        - cd copr-rust
+        - docker build -t copr-rust:stable .
+        - docker history copr-rust:stable
+        - docker build -t copr-rust:nightly --build-arg toolchain=nightly .
+        - docker history copr-rust:nightly
+    - stage: build
       name: "Build Copr Lustre"
       script:
         - cd copr-lustre-client
@@ -74,6 +82,20 @@ jobs:
         - cd copr
         - docker build --rm -t imlteam/copr .
         - docker push imlteam/copr
+    - stage: cd_copr_rust_stable
+      name: "Copr Rust Stable Continuous Deployment"
+      script:
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        - cd copr-rust
+        - docker build --rm -t imlteam/copr-rust:stable .
+        - docker push imlteam/copr-rust:stable
+    - stage: cd_copr_rust_nightly
+      name: "Copr Rust Nightly Continuous Deployment"
+      script:
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        - cd copr-rust
+        - docker build --rm -t imlteam/copr-rust:nightly --build-arg toolchain=nightly .
+        - docker push imlteam/copr-rust:nightly
     - stage: cd_copr_lustre
       name: "Copr Lustre Continuous Deployment"
       script:

--- a/copr-rust/Dockerfile
+++ b/copr-rust/Dockerfile
@@ -1,0 +1,7 @@
+FROM imlteam/copr
+
+ARG toolchain=stable
+RUN cd /root \
+  && curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $toolchain
+ENV PATH $PATH:/root/.cargo/bin
+ENV CARGO_HOME /root/.cargo

--- a/copr-rust/Dockerfile
+++ b/copr-rust/Dockerfile
@@ -1,7 +1,9 @@
 FROM imlteam/copr
 
 ARG toolchain=stable
-RUN cd /root \
+RUN yum install -y gcc \
+  && yum clean all \
+  && cd /root \
   && curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $toolchain
 ENV PATH $PATH:/root/.cargo/bin
 ENV CARGO_HOME /root/.cargo

--- a/copr/Dockerfile
+++ b/copr/Dockerfile
@@ -7,7 +7,7 @@ RUN yum install -y dnf epel-release \
   && dnf copr enable -y @copr/copr \
   && dnf install -y copr-cli \
   && yum -y copr enable -y managerforlustre/buildtools \
-  && yum install -y rust-bundled-packaging spectool \
+  && yum install -y spectool \
   && yum clean all \
   && dnf clean all \
   && mkdir /root/.config \


### PR DESCRIPTION
This patch adds a copr-rust image that will be tagged with both stable
and nightly variants.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>