### PR TITLE
Add missing deploy stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -139,11 +139,15 @@ stages:
     if: branch = master AND type = push AND fork = false
   - name: cd_copr
     if: branch = master AND type = push AND fork = false
+  - name: cd_copr_rust_stable
+    if: branch = master AND type = push AND fork = false
+  - name: cd_copr_rust_nightly
+    if: branch = master AND type = push AND fork = false
+  - name: cd_copr_wasm
+    if: branch = master AND type = push AND fork = false
   - name: cd_copr_lustre
     if: branch = master AND type = push AND fork = false
   - name: cd_copr_zfs
-    if: branch = master AND type = push AND fork = false
-  - name: cd_copr_wasm
     if: branch = master AND type = push AND fork = false
   - name: cd_copr_dotnet
     if: branch = master AND type = push AND fork = false


### PR DESCRIPTION
cd_copr_rust_stable and cd_copr_rust_nightly need to be added to the
deploy stages. They also should come before cd_copr_wasm as cd_copr_wasm
depends on the prior jobs.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>