### PR TITLE
Add image for Rust beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,8 @@ jobs:
         - docker history copr-rust:stable
         - docker build -t copr-rust:nightly --build-arg toolchain=nightly .
         - docker history copr-rust:nightly
+        - docker build -t copr-rust:beta --build-arg toolchain=beta .
+        - docker history copr-rust:beta
     - stage: build
       name: "Build Copr Lustre"
       script:
@@ -89,6 +91,13 @@ jobs:
         - cd copr-rust
         - docker build --rm -t imlteam/copr-rust:stable .
         - docker push imlteam/copr-rust:stable
+    - stage: cd_copr_rust_beta
+      name: "Copr Rust Beta Continuous Deployment"
+      script:
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        - cd copr-rust
+        - docker build --rm -t imlteam/copr-rust:beta --build-arg toolchain=beta .
+        - docker push imlteam/copr-rust:beta
     - stage: cd_copr_rust_nightly
       name: "Copr Rust Nightly Continuous Deployment"
       script:
@@ -140,6 +149,8 @@ stages:
   - name: cd_copr
     if: branch = master AND type = push AND fork = false
   - name: cd_copr_rust_stable
+    if: branch = master AND type = push AND fork = false
+  - name: cd_copr_rust_beta
     if: branch = master AND type = push AND fork = false
   - name: cd_copr_rust_nightly
     if: branch = master AND type = push AND fork = false

--- a/copr/Dockerfile
+++ b/copr/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:latest
+FROM centos:7
 WORKDIR /build
 RUN yum install -y dnf epel-release \
   && yum install -y yum-plugin-copr \

--- a/mock/Dockerfile
+++ b/mock/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:latest
+FROM centos:7
 
 RUN yum -y install epel-release yum-plugin-copr \
   && yum -y copr enable @mock/mock-stable \


### PR DESCRIPTION
Create a new CI stage to build the beta release of Rust.

We can use this instead of nightly for async / await support
going forward.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>