### PR TITLE
Install kmod-devel to bind to it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,12 @@ jobs:
         - docker build -t copr-zfs .
         - docker history copr-zfs
     - stage: build
+      name: "Build Copr kmod"
+      script:
+        - cd copr-kmod
+        - docker build -t copr-kmod .
+        - docker history copr-kmod  
+    - stage: build
       name: "Build Copr WASM"
       script:
         - cd copr-wasm
@@ -119,6 +125,13 @@ jobs:
         - cd copr-zfs
         - docker build --rm -t imlteam/copr-zfs .
         - docker push imlteam/copr-zfs
+    - stage: cd_copr_kmod
+      name: "Copr kmod Continuous Deployment"
+      script:
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        - cd copr-kmod
+        - docker build --rm -t imlteam/copr-kmod .
+        - docker push imlteam/copr-kmod
     - stage: cd_copr_wasm
       name: "Copr WASM Continuous Deployment"
       script:
@@ -159,6 +172,8 @@ stages:
   - name: cd_copr_lustre
     if: branch = master AND type = push AND fork = false
   - name: cd_copr_zfs
+    if: branch = master AND type = push AND fork = false
+  - name: cd_copr_kmod
     if: branch = master AND type = push AND fork = false
   - name: cd_copr_dotnet
     if: branch = master AND type = push AND fork = false

--- a/copr-kmod/Dockerfile
+++ b/copr-kmod/Dockerfile
@@ -1,0 +1,5 @@
+FROM imlteam/copr-rust
+
+RUN yum install -y clang llvm-devel \
+  && yum install -y kmod-devel \
+  && yum clean all

--- a/copr-kmod/Dockerfile
+++ b/copr-kmod/Dockerfile
@@ -1,4 +1,4 @@
-FROM imlteam/copr-rust
+FROM imlteam/copr-rust:stable
 
 RUN yum install -y clang llvm-devel \
   && yum install -y kmod-devel \

--- a/copr-rust/Dockerfile
+++ b/copr-rust/Dockerfile
@@ -2,8 +2,6 @@ FROM imlteam/copr
 
 ARG toolchain=stable
 RUN yum install -y gcc \
-  && yum install -y clang llvm-devel \
-  && yum install -y kmod-devel \
   && yum clean all \
   && cd /root \
   && curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $toolchain

--- a/copr-rust/Dockerfile
+++ b/copr-rust/Dockerfile
@@ -2,6 +2,8 @@ FROM imlteam/copr
 
 ARG toolchain=stable
 RUN yum install -y gcc \
+  && yum install -y clang llvm-devel \
+  && yum install -y kmod-devel \
   && yum clean all \
   && cd /root \
   && curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $toolchain


### PR DESCRIPTION
Install `clang` and `llvm-devel` as well so that `build.rs` and `bindgen` have all the dependencies.

Needed for https://github.com/whamcloud/integrated-manager-for-lustre/pull/1371