### PR TITLE
Handle exit codes

### DIFF
--- a/copr/create_build.py
+++ b/copr/create_build.py
@@ -56,7 +56,7 @@ except Exception:
         write_new_spec(spec, updated_spec)
 
     # Build the SRPM
-    subprocess.call(
+    code = subprocess.call(
         [
             "make",
             "-f",
@@ -67,11 +67,14 @@ except Exception:
         cwd=workspace,
     )
 
+    if code != 0:
+        sys.exit(1)
+
     p = glob.glob(srpm_path).pop()
 
 if local_only in valid_truthy_args:
     print("Building the RPM's from SRPM Locally.")
-    subprocess.call(
+    code = subprocess.call(
         [
             "rpmbuild",
             "--rebuild",
@@ -81,9 +84,13 @@ if local_only in valid_truthy_args:
         ],
         cwd=workspace,
     )
+
+    if code != 0:
+        sys.exit(1)
+
     print("RPM's located under: {}".format(os.path.join(workspace, "_topdir/RPMS")))
 else:
-    subprocess.call(
+    code = subprocess.call(
         [
             "openssl",
             "aes-256-cbc",
@@ -98,6 +105,9 @@ else:
             "-d",
         ]
     )
+
+    if code != 0:
+        sys.exit(1)
 
     client = Client.create_from_config_file("/root/.config/copr")
 

--- a/copr/create_build.py
+++ b/copr/create_build.py
@@ -56,7 +56,7 @@ except Exception:
         write_new_spec(spec, updated_spec)
 
     # Build the SRPM
-    code = subprocess.call(
+    subprocess.check_call(
         [
             "make",
             "-f",
@@ -67,14 +67,11 @@ except Exception:
         cwd=workspace,
     )
 
-    if code != 0:
-        sys.exit(1)
-
     p = glob.glob(srpm_path).pop()
 
 if local_only in valid_truthy_args:
     print("Building the RPM's from SRPM Locally.")
-    code = subprocess.call(
+    subprocess.check_call(
         [
             "rpmbuild",
             "--rebuild",
@@ -85,12 +82,9 @@ if local_only in valid_truthy_args:
         cwd=workspace,
     )
 
-    if code != 0:
-        sys.exit(1)
-
     print("RPM's located under: {}".format(os.path.join(workspace, "_topdir/RPMS")))
 else:
-    code = subprocess.call(
+    code = subprocess.check_call(
         [
             "openssl",
             "aes-256-cbc",
@@ -105,9 +99,6 @@ else:
             "-d",
         ]
     )
-
-    if code != 0:
-        sys.exit(1)
 
     client = Client.create_from_config_file("/root/.config/copr")
 

--- a/copr/create_build.py
+++ b/copr/create_build.py
@@ -84,7 +84,7 @@ if local_only in valid_truthy_args:
 
     print("RPM's located under: {}".format(os.path.join(workspace, "_topdir/RPMS")))
 else:
-    code = subprocess.check_call(
+    subprocess.check_call(
         [
             "openssl",
             "aes-256-cbc",


### PR DESCRIPTION
When building an RPM in the copr dockerfile, we do not check exit codes
after subprocess calls.

Update each call to check exit code and exit early if non-zero.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>