### PR TITLE
Create release-grabber docker image

### DIFF
--- a/copr-lustre-client/lustre-client.repo
+++ b/copr-lustre-client/lustre-client.repo
@@ -1,6 +1,6 @@
 [lustre-client]
 name=Lustre Client
-baseurl=https://downloads.whamcloud.com/public/lustre/lustre-2.12.3/el7/client/
+baseurl=https://downloads.whamcloud.com/public/lustre/lustre-2.12.4/el7/client/
 enabled=1
 gpgcheck=0
 repo_gpgcheck=0

--- a/release-grabber/Dockerfile
+++ b/release-grabber/Dockerfile
@@ -1,0 +1,10 @@
+FROM centos:7.7.1908
+
+WORKDIR /build
+
+COPY build-deps.sh /usr/bin/build-deps.sh
+
+RUN yum clean all \
+  && yum install -y createrepo
+
+CMD ["build-deps.sh"]

--- a/release-grabber/README.md
+++ b/release-grabber/README.md
@@ -1,0 +1,29 @@
+# Release Grabber
+
+This image provides a method to generate a local repo with IML. Images have been tagged for IML 6.0 and 6.1.
+
+## Examples
+
+To generate a repo with the base packages needed for IML 6.1 (Not including Lustre / ZFS)
+
+```sh
+docker run -v $(pwd):/build imlteam/release-grabber:6.1
+```
+
+To generate a repo with the base packages needed for IML 6.1 (Including patchless Lustre / ZFS)
+
+```sh
+docker run -v $(pwd):/build -e WITH_LUSTRE_PATCHLESS imlteam/release-grabber:6.1
+```
+
+To generate a repo with only the manager packages needed for IML 6.1
+
+```sh
+docker run -v $(pwd):/build -e MANAGER_ONLY imlteam/release-grabber:6.1
+```
+
+To generate a repo for IML 6.0 (Not including Lustre / ZFS):
+
+```sh
+docker run -v $(pwd):/build imlteam/release-grabber:6.0
+```

--- a/release-grabber/README.md
+++ b/release-grabber/README.md
@@ -13,11 +13,11 @@ docker run -v $(pwd):/build imlteam/release-grabber:6.2
 To generate a repo with the base packages needed for IML 6.2 (Including patchless Lustre / ZFS)
 
 ```sh
-docker run -v $(pwd):/build -e WITH_LUSTRE_PATCHLESS imlteam/release-grabber:6.2
+docker run -v $(pwd):/build -e WITH_LUSTRE_PATCHLESS=true imlteam/release-grabber:6.2
 ```
 
 To generate a repo with only the manager packages needed for IML 6.2
 
 ```sh
-docker run -v $(pwd):/build -e MANAGER_ONLY imlteam/release-grabber:6.2
+docker run -v $(pwd):/build -e MANAGER_ONLY=true imlteam/release-grabber:6.2
 ```

--- a/release-grabber/README.md
+++ b/release-grabber/README.md
@@ -1,29 +1,23 @@
 # Release Grabber
 
-This image provides a method to generate a local repo with IML. Images have been tagged for IML 6.0 and 6.1.
+This image provides a method to generate a local repo with IML. Images have been tagged for IML 6.2.
 
 ## Examples
 
-To generate a repo with the base packages needed for IML 6.1 (Not including Lustre / ZFS)
+To generate a repo with the base packages needed for IML 6.2 (Not including Lustre / ZFS)
 
 ```sh
-docker run -v $(pwd):/build imlteam/release-grabber:6.1
+docker run -v $(pwd):/build imlteam/release-grabber:6.2
 ```
 
-To generate a repo with the base packages needed for IML 6.1 (Including patchless Lustre / ZFS)
+To generate a repo with the base packages needed for IML 6.2 (Including patchless Lustre / ZFS)
 
 ```sh
-docker run -v $(pwd):/build -e WITH_LUSTRE_PATCHLESS imlteam/release-grabber:6.1
+docker run -v $(pwd):/build -e WITH_LUSTRE_PATCHLESS imlteam/release-grabber:6.2
 ```
 
-To generate a repo with only the manager packages needed for IML 6.1
+To generate a repo with only the manager packages needed for IML 6.2
 
 ```sh
-docker run -v $(pwd):/build -e MANAGER_ONLY imlteam/release-grabber:6.1
-```
-
-To generate a repo for IML 6.0 (Not including Lustre / ZFS):
-
-```sh
-docker run -v $(pwd):/build imlteam/release-grabber:6.0
+docker run -v $(pwd):/build -e MANAGER_ONLY imlteam/release-grabber:6.2
 ```

--- a/release-grabber/build-deps.sh
+++ b/release-grabber/build-deps.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -e
+
+: "${VERSION:=6.1.0}"
+: "${LUSTRE_VERSION:=2.12.4}"
+
+
+mkdir -p /tmp/iml-build
+cd /tmp/iml-build
+
+
+if [[ -z "$MANAGER_ONLY" && ! -z "$WITH_LUSTRE_PATCHLESS" ]]; then
+  echo "Adding e2fsprogs repo"
+
+  yum-config-manager --add-repo=https://downloads.whamcloud.com/public/e2fsprogs/latest/el7/
+
+  echo "Adding Patchless Lustre repos"
+
+  yum-config-manager --add-repo=https://downloads.whamcloud.com/public/lustre/lustre-${LUSTRE_VERSION}/el7/patchless-ldiskfs-server/
+  yum-config-manager --add-repo=http://download.zfsonlinux.org/epel/7.6/kmod/x86_64/
+
+  yumdownloader --resolve -y pcs fence-agents fence-agents-virsh lustre-resource-agents lustre-ldiskfs-zfs-patchles
+fi
+
+echo "Adding IML manager repos"
+
+yum-config-manager --add-repo=https://github.com/whamcloud/integrated-manager-for-lustre/releases/download/v$VERSION/chroma_support.repo
+yumdownloader --resolve -y python2-iml-manager
+
+if [[ -z "$MANAGER_ONLY" ]]; then
+  yumdownloader --resolve -y python2-iml-agent python2-iml-agent-management rust-iml-agent;
+fi
+
+createrepo --pretty ./
+cd /build
+tar -C /tmp -czvf iml-bundle-v${VERSION}.tar.gz iml-build

--- a/release-grabber/build-deps.sh
+++ b/release-grabber/build-deps.sh
@@ -10,7 +10,7 @@ mkdir -p /tmp/iml-build
 cd /tmp/iml-build
 
 
-if [[ -v "$WITH_LUSTRE_PATCHLESS" ]]; then
+if [[ "$WITH_LUSTRE_PATCHLESS" = true && "$MANAGER_ONLY" != true ]]; then
     echo "Adding e2fsprogs repo"
 
     yum-config-manager --add-repo=https://downloads.whamcloud.com/public/e2fsprogs/latest/el7/
@@ -28,7 +28,7 @@ echo "Adding IML manager repos"
 yum-config-manager --add-repo=https://github.com/whamcloud/integrated-manager-for-lustre/releases/download/v$VERSION/chroma_support.repo
 yumdownloader --resolve -y python2-iml-manager
 
-if [[ ! -v "$MANAGER_ONLY" ]]; then
+if [[ "$MANAGER_ONLY" != true ]]; then
     echo "Adding IML agent repos"
     yumdownloader --resolve -y python2-iml-agent python2-iml-agent-management rust-iml-agent;
 fi

--- a/release-grabber/build-deps.sh
+++ b/release-grabber/build-deps.sh
@@ -10,7 +10,7 @@ mkdir -p /tmp/iml-build
 cd /tmp/iml-build
 
 
-if [[ -z "$MANAGER_ONLY" && ! -z "$WITH_LUSTRE_PATCHLESS" ]]; then
+if [[ -v "$WITH_LUSTRE_PATCHLESS" ]]; then
     echo "Adding e2fsprogs repo"
 
     yum-config-manager --add-repo=https://downloads.whamcloud.com/public/e2fsprogs/latest/el7/
@@ -28,7 +28,8 @@ echo "Adding IML manager repos"
 yum-config-manager --add-repo=https://github.com/whamcloud/integrated-manager-for-lustre/releases/download/v$VERSION/chroma_support.repo
 yumdownloader --resolve -y python2-iml-manager
 
-if [[ -z "$MANAGER_ONLY" ]]; then
+if [[ ! -v "$MANAGER_ONLY" ]]; then
+    echo "Adding IML agent repos"
     yumdownloader --resolve -y python2-iml-agent python2-iml-agent-management rust-iml-agent;
 fi
 

--- a/release-grabber/build-deps.sh
+++ b/release-grabber/build-deps.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-: "${VERSION:=6.1.0}"
+: "${VERSION:=6.2.0}"
 : "${LUSTRE_VERSION:=2.12.4}"
 
 
@@ -11,16 +11,16 @@ cd /tmp/iml-build
 
 
 if [[ -z "$MANAGER_ONLY" && ! -z "$WITH_LUSTRE_PATCHLESS" ]]; then
-  echo "Adding e2fsprogs repo"
+    echo "Adding e2fsprogs repo"
 
-  yum-config-manager --add-repo=https://downloads.whamcloud.com/public/e2fsprogs/latest/el7/
+    yum-config-manager --add-repo=https://downloads.whamcloud.com/public/e2fsprogs/latest/el7/
 
-  echo "Adding Patchless Lustre repos"
+    echo "Adding Patchless Lustre repos"
 
-  yum-config-manager --add-repo=https://downloads.whamcloud.com/public/lustre/lustre-${LUSTRE_VERSION}/el7/patchless-ldiskfs-server/
-  yum-config-manager --add-repo=http://download.zfsonlinux.org/epel/7.6/kmod/x86_64/
+    yum-config-manager --add-repo=https://downloads.whamcloud.com/public/lustre/lustre-${LUSTRE_VERSION}/el7/patchless-ldiskfs-server/
+    yum-config-manager --add-repo=http://download.zfsonlinux.org/epel/7.6/kmod/x86_64/
 
-  yumdownloader --resolve -y pcs fence-agents fence-agents-virsh lustre-resource-agents lustre-ldiskfs-zfs-patchles
+    yumdownloader --resolve -y pcs fence-agents fence-agents-virsh lustre-resource-agents lustre-ldiskfs-zfs-patchles
 fi
 
 echo "Adding IML manager repos"
@@ -29,7 +29,7 @@ yum-config-manager --add-repo=https://github.com/whamcloud/integrated-manager-fo
 yumdownloader --resolve -y python2-iml-manager
 
 if [[ -z "$MANAGER_ONLY" ]]; then
-  yumdownloader --resolve -y python2-iml-agent python2-iml-agent-management rust-iml-agent;
+    yumdownloader --resolve -y python2-iml-agent python2-iml-agent-management rust-iml-agent;
 fi
 
 createrepo --pretty ./


### PR DESCRIPTION
There are cases where users need to download all IML deps prior to
running installation.

Our current recommendation for this is in https://github.com/whamcloud/Online-Help/blob/0d25dc6427688d340d38c2eff6a61ac5764b6a16/docs/Install_Guide/Create_Offline_Repos_10_0.md

It involves potentially mirroring all of EPEL / Extras.

We should be able to take a more targeted approach by directly resolving
deps we need and by providing flags to override defaults.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>